### PR TITLE
Add support for fragmented manifests

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 skip_list:
   - 'yaml'
   - 'role-name'
+  - 'empty-string-compare'

--- a/README.md
+++ b/README.md
@@ -25,9 +25,15 @@ Available variables are listed below, along with default values (see `defaults/m
       - dir: docker-registry
         namespace: registry
 
+      # You may keep your manifests in separate YML files like services.yml, deployment.yml (templated to `manifest_fragments`).
+      - dir: foo-bar
+        fragments: True
+
 A list of Kubernetes manifest directories to apply to a Kubernetes cluster. This list can either be raw directory paths or folder names, or can be a dict with `dir` (the directory path/folder name), optional `lookup_type` (the Ansible lookup type used for the `manifest.yml` file), and optional `namespace` (templated to `manifest_namespace`).
 
 This role then looks inside the specified directory for each manifest, and applies a `manifest.yml` file (and all its contents) using the Ansible `k8s` module.
+
+If you keep parts of your manifest groupped into separate YML files, you can concatenate them (in string sorting order) into a single manifest.yml file by setting `fragments: True`.
 
 If you need to template the file, this role templates the `manifest.yml` file by default (and automatically adds any variables in a `vars.yml` file alongside the `manifest.yml` file). But you can also disable templating and have the manifest applied directly by setting `lookup_type: file`.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Available variables are listed below, along with default values (see `defaults/m
       - dir: foo-bar
         fragments: True
 
+    # You can change fragments handling globally instead of setting up individually
+    k8s_manifests_fragments: true
+
 A list of Kubernetes manifest directories to apply to a Kubernetes cluster. This list can either be raw directory paths or folder names, or can be a dict with `dir` (the directory path/folder name), optional `lookup_type` (the Ansible lookup type used for the `manifest.yml` file), and optional `namespace` (templated to `manifest_namespace`).
 
 This role then looks inside the specified directory for each manifest, and applies a `manifest.yml` file (and all its contents) using the Ansible `k8s` module.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ k8s_manifests: []
 # - monitoring/prometheus
 # - dir: monitoring/grafana-configmap
 #   lookup_type: 'file'
+k8s_manifests_fragments: false
 k8s_manifests_base_dir: ''
 k8s_manifests_state: present
 k8s_force: false

--- a/meta/.galaxy_install_info
+++ b/meta/.galaxy_install_info
@@ -1,0 +1,2 @@
+install_date: "2022. m\xE1j. 6., p\xE9ntek, 10:42:35 "
+version: master

--- a/tasks/deploy-manifest.yml
+++ b/tasks/deploy-manifest.yml
@@ -31,7 +31,7 @@
     src: "{{ manifest_directory }}"
     dest: "{{ manifest_directory }}/manifest.yml"
     delimiter: "### START FRAGMENT ###"
-  when: manifest_fragments
+  when: manifest_fragments or k8s_manifests_fragments
 
 - name: Deploy the resources defined inside the manifest.
   k8s:

--- a/tasks/deploy-manifest.yml
+++ b/tasks/deploy-manifest.yml
@@ -35,12 +35,11 @@
 
 - name: Deploy the resources defined inside the manifest.
   k8s:
-    definition: "{{ item }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: "{{ k8s_manifests_state }}"
     force: "{{ k8s_force }}"
-  loop: "{{ lookup(manifest_lookup_type, manifest_directory + '/manifest.yml') | from_yaml_all | list }}"
     namespace: "{{ manifest_namespace }}"
+    src: "{{ manifest_directory + '/manifest.yml' }}"
   register: k8s_result
   until: k8s_result is success
   retries: 10

--- a/tasks/deploy-manifest.yml
+++ b/tasks/deploy-manifest.yml
@@ -3,7 +3,7 @@
   set_fact:
     manifest_directory: "{{ k8s_manifests_base_dir }}{{ outer_item.dir | default(outer_item) }}"
     manifest_lookup_type: "{{ outer_item.lookup_type | default('template') }}"
-    manifest_namespace: "{{ outer_item.namespace | default('') }}"
+    manifest_namespace: "{{ outer_item.namespace | default(k8s_resource_namespace, true) }}"
     manifest_fragments: "{{ outer_item.fragments | default(False) }}"
 
 - name: Print current manifest directory.
@@ -40,6 +40,7 @@
     state: "{{ k8s_manifests_state }}"
     force: "{{ k8s_force }}"
   loop: "{{ lookup(manifest_lookup_type, manifest_directory + '/manifest.yml') | from_yaml_all | list }}"
+    namespace: "{{ manifest_namespace }}"
   register: k8s_result
   until: k8s_result is success
   retries: 10

--- a/tasks/deploy-manifest.yml
+++ b/tasks/deploy-manifest.yml
@@ -31,6 +31,7 @@
     src: "{{ manifest_directory }}"
     dest: "{{ manifest_directory }}/manifest.yml"
     delimiter: "### START FRAGMENT ###"
+    mode: '0644'
   when: manifest_fragments or k8s_manifests_fragments
 
 - name: Deploy the resources defined inside the manifest.

--- a/tasks/deploy-manifest.yml
+++ b/tasks/deploy-manifest.yml
@@ -1,16 +1,16 @@
 ---
 - name: Set variables for this iteration of the loop.
-  set_fact:
+  ansible.builtin.set_fact:
     manifest_directory: "{{ k8s_manifests_base_dir }}{{ outer_item.dir | default(outer_item) }}"
     manifest_lookup_type: "{{ outer_item.lookup_type | default('template') }}"
     manifest_namespace: "{{ outer_item.namespace | default(k8s_resource_namespace, true) }}"
     manifest_fragments: "{{ outer_item.fragments | default(False) }}"
 
 - name: Print current manifest directory.
-  debug: var=manifest_directory
+  ansible.builtin.debug: var=manifest_directory
 
 - name: Ensure manifest-specific namespace exists.
-  k8s:
+  kubernetes.core.k8s:
     api_version: v1
     kind: Namespace
     name: "{{ manifest_namespace }}"
@@ -19,7 +19,7 @@
   when: manifest_namespace | default(false)
 
 - name: Include vars specific to this manifest.
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - files:
         - "{{ manifest_directory }}/vars.yml"
@@ -35,7 +35,7 @@
   when: manifest_fragments or k8s_manifests_fragments
 
 - name: Deploy the resources defined inside the manifest.
-  k8s:
+  kubernetes.core.k8s:
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: "{{ k8s_manifests_state }}"
     force: "{{ k8s_force }}"

--- a/tasks/deploy-manifest.yml
+++ b/tasks/deploy-manifest.yml
@@ -4,6 +4,7 @@
     manifest_directory: "{{ k8s_manifests_base_dir }}{{ outer_item.dir | default(outer_item) }}"
     manifest_lookup_type: "{{ outer_item.lookup_type | default('template') }}"
     manifest_namespace: "{{ outer_item.namespace | default('') }}"
+    manifest_fragments: "{{ outer_item.fragments | default(False) }}"
 
 - name: Print current manifest directory.
   debug: var=manifest_directory
@@ -23,6 +24,14 @@
     - files:
         - "{{ manifest_directory }}/vars.yml"
       skip: true
+
+- name: Assemble manifest.yml from fragments
+  ansible.builtin.assemble:
+    regexp: "^(?!vars|manifest).*?\\.(?:yml|yaml)$"
+    src: "{{ manifest_directory }}"
+    dest: "{{ manifest_directory }}/manifest.yml"
+    delimiter: "### START FRAGMENT ###"
+  when: manifest_fragments
 
 - name: Deploy the resources defined inside the manifest.
   k8s:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
 - name: Ensure at least one manifest is in the list.
-  fail:
+  ansible.builtin.fail:
     msg: "Please supply one or more k8s_manifests to apply."
   when: k8s_manifests == []
 
 - name: Ensure a namespace is set.
-  fail:
+  ansible.builtin.fail:
     msg: "The k8s_resource_namespace variable is not set."
   when:
     - k8s_manage_namespace
     - k8s_resource_namespace == ''
 
 - name: Ensure namespace exists.
-  k8s:
+  kubernetes.core.k8s:
     api_version: v1
     kind: Namespace
     name: "{{ k8s_resource_namespace }}"
@@ -21,7 +21,7 @@
   when: k8s_manage_namespace
 
 - name: Deploy manifests defined in k8s_manifests.
-  include_tasks: deploy-manifest.yml
+  ansible.builtin.include_tasks: deploy-manifest.yml
   loop: "{{ k8s_manifests }}"
   loop_control:
     loop_var: outer_item

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
     msg: "The k8s_resource_namespace variable is not set."
   when:
     - k8s_manage_namespace
-    - k8s_resource_namespace | default(true)
+    - k8s_resource_namespace == ''
 
 - name: Ensure namespace exists.
   k8s:


### PR DESCRIPTION
Hi,

My plan is to handle fragments of YAML files which will be later assembled into a single manifest.yml on the managed host.
It helps me to organize larger manifests, like having a separate YML file for each group of similar resources. For example: PV - PVC, Secret - ConfigMap, etc. Or have completely different type of groups of manifests in each directory.

The pull request also introduces a breaking change. The template `lookup plugin` was replaced with `ansible.builtin.template` using an explicit list of template files. It places the processed templates to the managed host so you can even use kubectl on them.
It is functional, although I am still looking for suggestions to get rid of this explicit list, and somehow use assemble and template lookup locally then transfer the assembled file to the managed node.

ps: Thanks @geerlingguy for all your amazing work on Ansible/K8s. I've learned a lot from them. :)
